### PR TITLE
Passing TF Params into Init 

### DIFF
--- a/Xam.Plugins.OnDeviceCustomVision.Droid/ImageClassifier.cs
+++ b/Xam.Plugins.OnDeviceCustomVision.Droid/ImageClassifier.cs
@@ -13,10 +13,6 @@ namespace Xam.Plugins.OnDeviceCustomVision
         private List<string> _labels;
         private TensorFlowInferenceInterface _inferenceInterface;
 
-        private static readonly int InputSize = 227;
-        private static readonly string InputName = "Placeholder";
-        private static readonly string OutputName = "loss";
-
         public override async Task<IReadOnlyList<ImageClassification>> ClassifyImage(Stream imageStream)
         {
             if (_labels == null || !_labels.Any() || _inferenceInterface == null)
@@ -37,9 +33,9 @@ namespace Xam.Plugins.OnDeviceCustomVision
             }
         }
 
-        public override void Init(string modelName, ModelType modelType)
+        public override void Init(string modelName, ModelType modelType, int inputSize = 227, string inputName = "Placeholder", string outputName = "loss")
         {
-            base.Init(modelName, modelType);
+            base.Init(modelName, modelType, inputSize, inputName, outputName);
 
             try
             {

--- a/Xam.Plugins.OnDeviceCustomVision.Shared/CrossImageClassifier.cs
+++ b/Xam.Plugins.OnDeviceCustomVision.Shared/CrossImageClassifier.cs
@@ -1,4 +1,5 @@
-﻿using System;
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -35,6 +36,7 @@ namespace Xam.Plugins.OnDeviceCustomVision
     public interface IImageClassifier
     {
         void Init(string modelName, ModelType modelType);
+        void Init(string modelName, ModelType modelType, int inputSize, string inputName, string outputName);
         Task<IReadOnlyList<ImageClassification>> ClassifyImage(Stream imageStream);
     }
 
@@ -42,6 +44,10 @@ namespace Xam.Plugins.OnDeviceCustomVision
     {
         protected string ModelName { get; private set; }
         protected ModelType ModelType { get; private set; }
+        
+        protected int InputSize { get; private set; }
+        protected string InputName { get; private set; }
+        protected string OutputName { get; private set; }
 
         public virtual void Init(string modelName, ModelType modelType)
         {
@@ -50,6 +56,19 @@ namespace Xam.Plugins.OnDeviceCustomVision
 
             ModelName = modelName;
             ModelType = modelType;
+        }
+        
+        public virtual void Init(string modelName, ModelType modelType, int inputSize, string inputName, string outputName)
+        {
+            if (string.IsNullOrEmpty(modelName))
+                throw new ArgumentException("modelName must be set", nameof(modelName));
+
+            ModelName = modelName;
+            ModelType = modelType;
+
+            InputSize = inputSize;
+            InputName = inputName;
+            OutputName = outputName;
         }
 
         public abstract Task<IReadOnlyList<ImageClassification>> ClassifyImage(Stream imageStream);


### PR DESCRIPTION
I found this didn't work for Tensorflow models produced outside of customvision.ai with different inputsizes and model parameter names. Making them optional to pass in makes this package more flexible.