### PR TITLE
Loading InputSize according to model's shape

### DIFF
--- a/Xam.Plugins.OnDeviceCustomVision/ImageClassifier.android.cs
+++ b/Xam.Plugins.OnDeviceCustomVision/ImageClassifier.android.cs
@@ -24,7 +24,7 @@ namespace Xam.Plugins.OnDeviceCustomVision
         private bool _hasNormalizationLayer;
         private ModelType _modelType;
 
-        private const int InputSize = 227;
+        private static int InputSize = 227;
         private const string InputName = "Placeholder";
         private const string OutputName = "loss";
         private const string DataNormLayerPrefix = "data_bn";
@@ -63,7 +63,7 @@ namespace Xam.Plugins.OnDeviceCustomVision
                 }
 
                 _inferenceInterface = new TensorFlowInferenceInterface(assets, modelName);
-
+                InputSize = Convert.ToInt32(_inferenceInterface.GraphOperation(InputName).Output(0).Shape().Size(1));
                 var iter = _inferenceInterface.Graph().Operations();
                 while (iter.HasNext && !_hasNormalizationLayer)
                 {


### PR DESCRIPTION
Fixing #8 [Crash on Android using exported models from latests azure custom vision update](https://github.com/jimbobbennett/Xam.Plugins.OnDeviceCustomVision/issues/8).

Solve the issue by getting the model InputSize dynamically and not hardcoded (227). Some models for example can have an InputSize of 225, and Tensorflow refuses to accept another size after the initialization with 227.

References : [https://medium.com/capital-one-tech/using-a-pre-trained-tensorflow-model-on-android-part-2-153ebdd4c465](https://medium.com/capital-one-tech/using-a-pre-trained-tensorflow-model-on-android-part-2-153ebdd4c465)