### PR TITLE
Adding the modelPath for iOS uncompiled models

### DIFF
--- a/Xam.Plugins.OnDeviceCustomVision/ImageClassifier.ios.cs
+++ b/Xam.Plugins.OnDeviceCustomVision/ImageClassifier.ios.cs
@@ -37,7 +37,7 @@ namespace Xam.Plugins.OnDeviceCustomVision
                 else
                     modelPath = NSBundle.MainBundle.GetUrlForResource(modelName, "mlmodelc");
             else
-                CompileModel(modelName, isPath);
+                modelPath = CompileModel(modelName, isPath);
 
             if (modelPath == null)
                 throw new ImageClassifierException($"Model {modelName} does not exist");


### PR DESCRIPTION
Bug introduced in https://github.com/jimbobbennett/Xam.Plugins.OnDeviceCustomVision/pull/10